### PR TITLE
Update maintainer team name (again)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,4 +19,4 @@
 # *.go docs@example.com
 
 # For more examples see https://help.github.com/articles/about-code-owners/
-* @OctopusDeploy/team-engineering-productivity-maintainers
+* @OctopusDeploy/team-engprod


### PR DESCRIPTION
[SC-4901] - We decided `team-engineering-productivity-maintainers` was too long, we convinced TSO to change it to `team-engprod`.