### PR TITLE
Fix path for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 
 updates:
   - package-ecosystem: "nuget"
-    directory: "/source/"
+    directory: "/source/NukeBuildComponents"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
Dependabot was 😢 because it was pointing at the wrong folder.