### PR TITLE
Push output data directly into the environment file

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageDownload Include="JetBrains.ReSharper.GlobalTools" Version="[2021.2.0]" />
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.43]" />
+    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.149]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageDownload Include="JetBrains.ReSharper.GlobalTools" Version="[2021.2.0]" />
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.149]" />
+    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[0.3.149]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/NukeBuildComponents/IOutputPackagesToPush.cs
+++ b/source/NukeBuildComponents/IOutputPackagesToPush.cs
@@ -22,7 +22,6 @@ namespace Octopus.NukeBuildComponents
                 {
                     var jobOutputFile = (AbsolutePath)Environment.GetEnvironmentVariable("GITHUB_OUTPUT");
                     File.AppendAllText(jobOutputFile, $"packages_to_push={string.Join(',', artifactPaths)}");
-                    // Console.WriteLine($"::set-output name=packages_to_push::{string.Join(',', artifactPaths)}");
                 }
                 
                 

--- a/source/NukeBuildComponents/IOutputPackagesToPush.cs
+++ b/source/NukeBuildComponents/IOutputPackagesToPush.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using Nuke.Common;
 using Nuke.Common.IO;
@@ -16,7 +17,15 @@ namespace Octopus.NukeBuildComponents
                     .Where(p => p is not null)
                     .Select(p => p.ToString());
 
-                Console.WriteLine($"::set-output name=packages_to_push::{string.Join(',', artifactPaths)}");
+                // This is done to pass the data to github actions
+                if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is not null)
+                {
+                    var jobOutputFile = (AbsolutePath)Environment.GetEnvironmentVariable("GITHUB_OUTPUT");
+                    File.AppendAllText(jobOutputFile, $"packages_to_push={string.Join(',', artifactPaths)}");
+                    // Console.WriteLine($"::set-output name=packages_to_push::{string.Join(',', artifactPaths)}");
+                }
+                
+                
             });
     }
 }

--- a/source/NukeBuildComponents/IPackComponent.cs
+++ b/source/NukeBuildComponents/IPackComponent.cs
@@ -23,9 +23,7 @@ namespace Octopus.NukeBuildComponents
                     var jobOutputFile = (AbsolutePath)Environment.GetEnvironmentVariable("GITHUB_OUTPUT");
                     
                     File.AppendAllText(jobOutputFile, $"semver={OctoVersionInfo.FullSemVer}");
-                    // Console.Out.WriteLine($"::set-output name=semver::{OctoVersionInfo.FullSemVer}");
                     File.AppendAllText(jobOutputFile, $"prerelease_tag={OctoVersionInfo.PreReleaseTagWithDash}");
-                    // Console.Out.WriteLine($"::set-output name=prerelease_tag::{OctoVersionInfo.PreReleaseTagWithDash}");
                 }
                 DotNetPack(_ => _
                     .SetProject(Solution)

--- a/source/NukeBuildComponents/IPackComponent.cs
+++ b/source/NukeBuildComponents/IPackComponent.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using Nuke.Common;
+using Nuke.Common.IO;
 using Nuke.Common.Tools.DotNet;
 using Serilog;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
@@ -16,9 +18,15 @@ namespace Octopus.NukeBuildComponents
                 Log.Information("Packing {1} v{0}", OctoVersionInfo.FullSemVer, TargetPackageDescription);
 
                 // This is done to pass the data to github actions
-                Console.Out.WriteLine($"::set-output name=semver::{OctoVersionInfo.FullSemVer}");
-                Console.Out.WriteLine($"::set-output name=prerelease_tag::{OctoVersionInfo.PreReleaseTagWithDash}");
-
+                if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is not null)
+                {
+                    var jobOutputFile = (AbsolutePath)Environment.GetEnvironmentVariable("GITHUB_OUTPUT");
+                    
+                    File.AppendAllText(jobOutputFile, $"semver={OctoVersionInfo.FullSemVer}");
+                    // Console.Out.WriteLine($"::set-output name=semver::{OctoVersionInfo.FullSemVer}");
+                    File.AppendAllText(jobOutputFile, $"prerelease_tag={OctoVersionInfo.PreReleaseTagWithDash}");
+                    // Console.Out.WriteLine($"::set-output name=prerelease_tag::{OctoVersionInfo.PreReleaseTagWithDash}");
+                }
                 DotNetPack(_ => _
                     .SetProject(Solution)
                     .SetVersion(OctoVersionInfo.FullSemVer)

--- a/source/NukeBuildComponents/IPackExtension.cs
+++ b/source/NukeBuildComponents/IPackExtension.cs
@@ -25,9 +25,7 @@ namespace Octopus.NukeBuildComponents
                 {
                     var jobOutputFile = (AbsolutePath)Environment.GetEnvironmentVariable("GITHUB_OUTPUT");
                     File.AppendAllText(jobOutputFile, $"semver={OctoVersionInfo.FullSemVer}");
-                    // Console.Out.WriteLine($"::set-output name=semver::{OctoVersionInfo.FullSemVer}");
                     File.AppendAllText(jobOutputFile, $"prerelease_tag={OctoVersionInfo.PreReleaseTagWithDash}");
-                    // Console.Out.WriteLine($"::set-output name=prerelease_tag::{OctoVersionInfo.PreReleaseTagWithDash}");
                 }
 
                 DotNetPack(c => c

--- a/source/NukeBuildComponents/IPackExtension.cs
+++ b/source/NukeBuildComponents/IPackExtension.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using Nuke.Common;
+using Nuke.Common.IO;
 using Nuke.Common.Tools.DotNet;
 using Serilog;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
@@ -9,6 +11,7 @@ namespace Octopus.NukeBuildComponents
     public interface IPackExtension : IOctopusNukeBuild
     {
         public string NuspecFilePath { get; }
+       
 
         Target Pack => _ => _
             .TryDependsOn<ITest>(x => x.Test)
@@ -18,8 +21,14 @@ namespace Octopus.NukeBuildComponents
                 Log.Information("Packing {1} v{0}", OctoVersionInfo.FullSemVer, TargetPackageDescription);
 
                 // This is done to pass the data to github actions
-                Console.Out.WriteLine($"::set-output name=semver::{OctoVersionInfo.FullSemVer}");
-                Console.Out.WriteLine($"::set-output name=prerelease_tag::{OctoVersionInfo.PreReleaseTagWithDash}");
+                if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is not null)
+                {
+                    var jobOutputFile = (AbsolutePath)Environment.GetEnvironmentVariable("GITHUB_OUTPUT");
+                    File.AppendAllText(jobOutputFile, $"semver={OctoVersionInfo.FullSemVer}");
+                    // Console.Out.WriteLine($"::set-output name=semver::{OctoVersionInfo.FullSemVer}");
+                    File.AppendAllText(jobOutputFile, $"prerelease_tag={OctoVersionInfo.PreReleaseTagWithDash}");
+                    // Console.Out.WriteLine($"::set-output name=prerelease_tag::{OctoVersionInfo.PreReleaseTagWithDash}");
+                }
 
                 DotNetPack(c => c
                     .SetProject(Solution)


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

This is the supported way to do this going forward.

I considered PRing upstream Nuke (and still might) but this is is tactical fix only at this point.